### PR TITLE
fix(package.json): Changing array to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "web"
   ],
   "homepage": "https://github.com/drblue/bootstrap-material-datetimepicker",
-  "main": [
-    "js/bootstrap-material-datetimepicker.js",
-    "css/bootstrap-material-datetimepicker.css"
-  ],
+  "main": "js/bootstrap-material-datetimepicker.js",
   "ignore": [
     "/.*",
     "_config.yml",


### PR DESCRIPTION
When running `npm install` an error is thrown:

> npm ERR! Path must be a string. Received [ 'js/bootstrap-material-datetimepicker.js', npm ERR!   'css/bootstrap-material-datetimepicker.css' ]

This change allows npm users the ability to install the dependency.
