### PR TITLE
Relax dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test-infra"
   ],
   "dependencies": {
-    "moment": "~2.10.2",
-    "angular-material": "~1.0.6"
+    "moment": "^2.10.2",
+    "angular-material": "^1.0.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allow to use more recent versions of angular-material (1.1.1)
while still keeping the same minimal requirement.